### PR TITLE
improved TX code

### DIFF
--- a/Jarolift_MQTT.ino
+++ b/Jarolift_MQTT.ino
@@ -75,8 +75,8 @@ extern "C" {
 #define DRD_ADDRESS 0
 
 // User configuration
-#define Lowpulse         400    // Defines pulse-width in microseconds. Adapt for your use...
-#define Highpulse        800
+#define PULSE_SHORT      400    // Defines pulse-width in microseconds. Adapt for your use...
+#define PULSE_LONG       800
 
 #define BITS_SIZE          8
 byte syncWord            = 199;


### PR DESCRIPTION
outcome of analyzing original remotes' signals:
- re-structured preamble/start-of-frame for better understanding
- fixed some timings (seems to be symmetrical)
- added TX cmd to achieve a defined level for end-of-frame delimiter

definitively improved shutter reliability in my environment 